### PR TITLE
Make larasearch's Reponse->getRecords() return a models Collection when total hits is 0

### DIFF
--- a/src/Iverberk/Larasearch/Response.php
+++ b/src/Iverberk/Larasearch/Response.php
@@ -56,7 +56,7 @@ class Response {
 	 */
 	public function getRecords()
 	{
-		if($this->getTotal() > 0)
+		if(count($this->getHits()) > 0)
 		{
 			$ids = array_map(function ($hit)
 				{


### PR DESCRIPTION
Make larasearch's Reponse->getRecords() return a models Collection when total hits is 0, instead of failing"
Larasearch\Response->getRecords() throws exception when no hits.

See #27 
