### PR TITLE
Added index prefix

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -198,7 +198,8 @@ return array_merge($pathConfig, array(
                     ]
                 ]
             ]
-        ]
+        ],
+        'index_prefix' => Illuminate\Support\Facades\App::environment() . '_'
     ]
 
 ));

--- a/tests/Iverberk/Larasearch/IndexTest.php
+++ b/tests/Iverberk/Larasearch/IndexTest.php
@@ -72,7 +72,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          *
          * @var \Mockery\Mock $index
          */
-        list($index) = $this->getMocks();
+        list($index) = $this->getMocks('bar_');
 
         /**
          *
@@ -80,7 +80,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          *
          */
         $this->assertEquals($index, $index->setName('Mock'));
-        $this->assertEquals('Mock', $index->getName());
+        $this->assertEquals('bar_Mock', $index->getName());
     }
 
     /**
@@ -125,7 +125,6 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          * Expectation
          *
          */
-        Facade::clearResolvedInstances();
         Config::shouldReceive('get')
             ->with('larasearch::elasticsearch.analyzers')
             ->andReturn([
@@ -1029,7 +1028,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          */
         $client->shouldReceive('indices->updateAliases')
             ->with([
-                'body' => ['actions']
+                'body' => ['actions' => []]
             ]);
 
         /**
@@ -1037,7 +1036,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          * Assertion
          *
          */
-        Index::updateAliases(['actions']);
+        Index::updateAliases(['actions' => []]);
     }
 
     /**
@@ -1117,11 +1116,20 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
      *
      * @return array
      */
-    private function getMocks()
+    private function getMocks($index_prefix = null)
     {
+        /**
+         *
+         * Expectation
+         *
+         */
+        Facade::clearResolvedInstances();
+        Config::shouldReceive('get')
+            ->with('larasearch::elasticsearch.index_prefix', '')
+            ->andReturn($index_prefix);
+
         $client = m::mock('Elasticsearch\Client');
 
-        Facade::clearResolvedInstances();
         App::shouldReceive('make')
             ->with('Elasticsearch')
             ->andReturn($client);


### PR DESCRIPTION
This adds the ability to prefix indexes with a constant string, e.g. `Illuminate\Support\Facades\App::environment()`.  This way the same elastic search cluster can be used for different environments / applications.

A `index_prefix` key has been added to the `laraserach::elasticsearch` configuration array.  It defaults to `Illuminate\Support\Facades\App::environment()`.
