### PR TITLE
Force lowercase index name

### DIFF
--- a/src/Iverberk/Larasearch/Index.php
+++ b/src/Iverberk/Larasearch/Index.php
@@ -123,7 +123,7 @@ class Index {
 	{
 		if ( ! is_null($this->name))
 		{
-			return Config::get('larasearch::elasticsearch.index_prefix', '') . $this->name;
+			return Config::get('larasearch::elasticsearch.index_prefix', '') . strtolower($this->name);
 		}
 	}
 


### PR DESCRIPTION
This commit forces the index name to be lowercase to comply with Elasticsearch requirements.

By default, the index name is determined from the name of the table in your database. If that table name is capitalized, it will try to name the index with a capital letter. Elasticsearch will throw an `InvalidIndexNameException`.
