### PR TITLE
Fix Paths Discovery / Added extensive test for index_prefix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "illuminate/database": "~4.2|~5.0",
         "illuminate/console": "~4.2|~5.0",
         "doctrine/dbal": "~2.3",
-        "elasticsearch/elasticsearch": "~1.0"
+        "elasticsearch/elasticsearch": "~1.0",
+        "nikic/php-parser": "*"
     },
     "autoload": {
         "psr-0": {
@@ -27,7 +28,7 @@
     },
     "require-dev": {
         "mockery/mockery": "dev-master",
-        "phpunit/phpunit": "4.5.*@dev",
+        "phpunit/phpunit": "4.6.*@dev",
         "phpunit/php-code-coverage": "3.0.*@dev",
         "phpunit/phpunit-mock-objects": "2.4.*@dev",
         "sebastian/global-state": "1.0.*@dev",

--- a/src/Iverberk/Larasearch/Index.php
+++ b/src/Iverberk/Larasearch/Index.php
@@ -37,6 +37,17 @@ class Index {
 	private $proxy;
 
 	/**
+	 * Retrieve the ElasticSearch Client
+	 *
+	 * @return \Elasticsearch\Client
+	 */
+	private static function getClient()
+	{
+        return self::$client;
+	}
+
+
+	/**
 	 * @param string $name
 	 * @param Proxy  $proxy
 	 */
@@ -44,8 +55,8 @@ class Index {
 	{
 		self::$client = App::make('Elasticsearch');
 
-		$this->proxy = $proxy;
-		$this->name = $name ?: $proxy->getModel()->getTable();
+		$this->setProxy($proxy);
+		$this->setName($name ?: $proxy->getModel()->getTable());
 	}
 
 	/**
@@ -109,6 +120,9 @@ class Index {
 	 */
 	public function setName($name)
 	{
+		$index_prefix = Config::get('larasearch::elasticsearch.index_prefix', '');
+		if ($index_prefix && ! Str::startsWith($name, $index_prefix)) $name = $index_prefix . $name;
+
 		$this->name = $name;
 
 		return $this;
@@ -121,10 +135,31 @@ class Index {
 	 */
 	public function getName()
 	{
-		if ( ! is_null($this->name))
-		{
-			return Config::get('larasearch::elasticsearch.index_prefix', '') . $this->name;
-		}
+		return $this->name;
+	}
+
+	/**
+	 * Set ElasticSearch Proxy for the index
+	 *
+	 * @param Proxy $proxy 
+	 * @return Iverberk\Larasearch\Prox
+	 * @author Chris Nagle
+	 */
+	public function setProxy(Proxy $proxy)
+	{
+		$this->proxy = $proxy;
+
+		return $proxy;
+	}
+
+	/**
+	 * Get ElasticSearch Proxy for the index
+	 *
+	 * @return Iverberk\Larasearch\Prox
+	 */
+	public function getProxy()
+	{
+		return $this->proxy;
 	}
 
 	/**
@@ -136,7 +171,7 @@ class Index {
 	{
 		$body = empty($options) ? $this->getDefaultIndexParams() : $options;
 
-		self::$client->indices()->create(['index' => $this->getName(), 'body' => $body]);
+		self::getClient()->indices()->create(['index' => $this->getName(), 'body' => $body]);
 	}
 
 	/**
@@ -144,7 +179,7 @@ class Index {
 	 */
 	public function delete()
 	{
-		self::$client->indices()->delete(['index' => $this->getName()]);
+		self::getClient()->indices()->delete(['index' => $this->getName()]);
 	}
 
 	/**
@@ -154,7 +189,7 @@ class Index {
 	 */
 	public function exists()
 	{
-		return self::$client->indices()->exists(['index' => $this->getName()]);
+		return self::getClient()->indices()->exists(['index' => $this->getName()]);
 	}
 
 	/**
@@ -165,7 +200,10 @@ class Index {
 	 */
 	public function aliasExists($alias)
 	{
-		return self::$client->indices()->existsAlias(['name' => $alias]);
+		$index_prefix = Config::get('larasearch::elasticsearch.index_prefix', '');
+		if ($index_prefix && ! Str::startsWith($alias, $index_prefix)) $alias = $index_prefix . $alias;
+
+		return self::getClient()->indices()->existsAlias(['name' => $alias]);
 	}
 
 	/**
@@ -180,7 +218,7 @@ class Index {
 		$params['id'] = $record['id'];
 		$params['body'] = $record['data'];
 
-		self::$client->index($params);
+		self::getClient()->index($params);
 	}
 
 	/**
@@ -194,7 +232,7 @@ class Index {
 		$params['type'] = $record['type'];
 		$params['id'] = $record['id'];
 
-		self::$client->get($params);
+		self::getClient()->get($params);
 	}
 
 	/**
@@ -208,7 +246,7 @@ class Index {
 		$params['type'] = $record['type'];
 		$params['id'] = $record['id'];
 
-		self::$client->delete($params);
+		self::getClient()->delete($params);
 	}
 
 	/**
@@ -219,7 +257,7 @@ class Index {
 	 */
 	public function tokens($text, $options = [])
 	{
-		self::$client->indices()->analyze(array_merge(['index' => $this->getName(), 'text' => $text], $options));
+		self::getClient()->indices()->analyze(array_merge(['index' => $this->getName(), 'text' => $text], $options));
 	}
 
 	/**
@@ -245,10 +283,10 @@ class Index {
 	public function bulk($records)
 	{
 		$params['index'] = $this->getName();
-		$params['type'] = $this->proxy->getType();
+		$params['type'] = $this->getProxy()->getType();
 		$params['body'] = $records;
 
-		$results = self::$client->bulk($params);
+		$results = self::getClient()->bulk($params);
 
 		if ($results['errors'])
 		{
@@ -276,12 +314,12 @@ class Index {
 		$index_prefix = Config::get('larasearch::elasticsearch.index_prefix', '');
 		if ($index_prefix && ! Str::startsWith($name, $index_prefix)) $name = $index_prefix . $name;
 
-		$indices = self::$client->indices()->getAliases();
+		$indices = self::getClient()->indices()->getAliases();
 		foreach ($indices as $index => $value)
 		{
 			if (empty($value['aliases']) && preg_match("/^${name}_\\d{14,17}$/", $index))
 			{
-				self::$client->indices()->delete(['index' => $index]);
+				self::getClient()->indices()->delete(['index' => $index]);
 			}
 		}
 	}
@@ -297,7 +335,7 @@ class Index {
 		$index_prefix = Config::get('larasearch::elasticsearch.index_prefix', '');
 		if ($index_prefix && ! Str::startsWith($name, $index_prefix)) $name = $index_prefix . $name;
 
-		return self::$client->indices()->getAlias(['name' => $name]);
+		return self::getClient()->indices()->getAlias(['name' => $name]);
 	}
 
 	/**
@@ -316,7 +354,7 @@ class Index {
 			}
 		}
 
-		return self::$client->indices()->updateAliases(['body' => $actions]);
+		return self::getClient()->indices()->updateAliases(['body' => $actions]);
 	}
 
 	/**
@@ -330,7 +368,7 @@ class Index {
 		$index_prefix = Config::get('larasearch::elasticsearch.index_prefix', '');
 		if ($index_prefix && ! Str::startsWith($index, $index_prefix)) $index = $index_prefix . $index;
 
-		return self::$client->indices()->refresh(['index' => $index]);
+		return self::getClient()->indices()->refresh(['index' => $index]);
 	}
 
 	/**
@@ -348,7 +386,7 @@ class Index {
 			$analyzers,
 			array_map(function ($type)
 				{
-					return Utils::findKey($this->proxy->getConfig(), $type, false) ?: [];
+					return Utils::findKey($this->getProxy()->getConfig(), $type, false) ?: [];
 				},
 				$analyzers
 			)
@@ -406,7 +444,7 @@ class Index {
 		if (!empty($mapping)) $params['mappings']['_default_']['properties'] = $mapping;
 
 		$params['index'] = $this->getName();
-		$params['type'] = $this->proxy->getType();
+		$params['type'] = $this->getProxy()->getType();
 
 		return $params;
 	}

--- a/src/Iverberk/Larasearch/Utils.php
+++ b/src/Iverberk/Larasearch/Utils.php
@@ -1,6 +1,12 @@
 <?php namespace Iverberk\Larasearch;
 
-use DirectoryIterator;
+use PHPParser_Parser;
+use PHPParser_Lexer;
+use PHPParser_Node_Stmt_Namespace;
+Use PHPParser_Node_Stmt_Class;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RegexIterator;
 
 class Utils {
 
@@ -63,50 +69,43 @@ class Utils {
 	public static function findSearchableModels($directories)
 	{
 		$models = [];
+		$parser = new PHPParser_Parser(new PHPParser_Lexer);
 
 		// Iterate over each directory and inspect files for models
 		foreach ($directories as $directory)
 		{
-			$dir = new DirectoryIterator($directory);
-			foreach ($dir as $fileinfo)
+            // iterate over all .php files in the directory
+			$files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($directory));
+			$files = new RegexIterator($files, '/\.php$/');
+
+			foreach ($files as $file)
 			{
-				$namespace = '';
+				// read the file that should be converted
+				$code = file_get_contents($file);
 
-				if (!$fileinfo->isDot() && $fileinfo->isReadable())
+				// parse
+				$stmts = $parser->parse($code);
+
+				$walk = function($stmt, $key, $ns) use (&$models, &$walk)
 				{
-
-    				if ($fileinfo->isDir())
-    				{
-        				$models = array_merge($models, static::findSearchableModels([$fileinfo->getPathname()]));
-        			}
-    				else
-    				{
-						$fileObj = $fileinfo->openFile('r');
-
-						while (!$fileObj->eof())
+					if ($stmt instanceof PHPParser_Node_Stmt_Namespace)
+					{
+						$new_ns = implode('\\', $stmt->name->parts);
+						if ($ns && strpos($new_ns, $ns) !== 0) $new_ns = $ns . $new_ns;
+						array_walk($stmt->stmts, $walk, $new_ns);
+					}
+					else if ($stmt instanceof PHPParser_Node_Stmt_Class)
+					{
+						$class = $stmt->name;
+						if ($ns) $class = $ns . '\\' . $class;
+						if (in_array('Iverberk\\Larasearch\\Traits\\SearchableTrait', class_uses($class)))
 						{
-							$line = $fileObj->fgets();
-
-							// Extract namespace
-							if (preg_match('/^(?:<\?(?:[Pp][Hh][Pp])?)?\s+namespace\s+([a-zA-z0-9_]+)/', $line, $matches))
-							{
-								$namespace = $matches[1];
-							}
-
-							// Extract classname
-							if (preg_match('/^(?:<\?(?:[Pp][Hh][Pp])?)?\s*class\s+([a-zA-z0-9_]+)/', $line, $matches))
-							{
-								$model = $namespace ? $namespace . '\\' . $matches[1] : $matches[1];
-
-								// Check if the model has the searchable trait
-								if (in_array('Iverberk\\Larasearch\\Traits\\SearchableTrait', class_uses($model)))
-								{
-									$models[] = $model;
-								}
-							}
+							$models[] = $class;
 						}
 					}
-				}
+				};
+
+				array_walk($stmts, $walk, '');
 			}
 		}
 

--- a/src/Iverberk/Larasearch/Utils.php
+++ b/src/Iverberk/Larasearch/Utils.php
@@ -74,27 +74,35 @@ class Utils {
 
 				if (!$fileinfo->isDot() && $fileinfo->isReadable())
 				{
-					$fileObj = $fileinfo->openFile('r');
 
-					while (!$fileObj->eof())
-					{
-						$line = $fileObj->fgets();
+    				if ($fileinfo->isDir())
+    				{
+        				$models = array_merge($models, static::findSearchableModels([$fileinfo->getPathname()]));
+        			}
+    				else
+    				{
+						$fileObj = $fileinfo->openFile('r');
 
-						// Extract namespace
-						if (preg_match('/namespace\s+([a-zA-z0-9]+)/', $line, $matches))
+						while (!$fileObj->eof())
 						{
-							$namespace = $matches[1];
-						}
+							$line = $fileObj->fgets();
 
-						// Extract classname
-						if (preg_match('/class\s+([a-zA-z0-9]+)/', $line, $matches))
-						{
-							$model = $namespace ? $namespace . '\\' . $matches[1] : $matches[1];
-
-							// Check if the model has the searchable trait
-							if (in_array('Iverberk\\Larasearch\\Traits\\SearchableTrait', class_uses($model)))
+							// Extract namespace
+							if (preg_match('/^(?:<\?(?:[Pp][Hh][Pp])?)?\s+namespace\s+([a-zA-z0-9_]+)/', $line, $matches))
 							{
-								$models[] = $model;
+								$namespace = $matches[1];
+							}
+
+							// Extract classname
+							if (preg_match('/^(?:<\?(?:[Pp][Hh][Pp])?)?\s*class\s+([a-zA-z0-9_]+)/', $line, $matches))
+							{
+								$model = $namespace ? $namespace . '\\' . $matches[1] : $matches[1];
+
+								// Check if the model has the searchable trait
+								if (in_array('Iverberk\\Larasearch\\Traits\\SearchableTrait', class_uses($model)))
+								{
+									$models[] = $model;
+								}
 							}
 						}
 					}

--- a/tests/Iverberk/Larasearch/Commands/PathsCommandTest.php
+++ b/tests/Iverberk/Larasearch/Commands/PathsCommandTest.php
@@ -136,7 +136,7 @@ class PathsCommandTest extends \PHPUnit_Framework_TestCase {
 
         $command->shouldReceive('option')
             ->with('relations')
-            ->times(16)
+            ->times(17)
             ->andReturn(true);
 
         $command->shouldReceive('error', 'confirm', 'call', 'info')
@@ -154,7 +154,8 @@ class PathsCommandTest extends \PHPUnit_Framework_TestCase {
                 'Husband' => ['wife.children.toys'],
                 'Child' => ['mother', 'father', 'toys'],
                 'Toy' => ['children.mother', 'children.father'],
-                'Wife' => ['husband', 'children.toys']
+                'Wife' => ['husband', 'children.toys'],
+                'House\\Item' => []
             ],
             $command->getPaths()
         );
@@ -164,7 +165,8 @@ class PathsCommandTest extends \PHPUnit_Framework_TestCase {
                 'Husband' => ['', 'children', 'children.toys', 'wife'],
                 'Child' => ['mother.husband', '', 'toys', 'mother'],
                 'Toy' => ['children.mother.husband', 'children', '', 'children.mother'],
-                'Wife' => ['husband', 'children', 'children.toys', '']
+                'Wife' => ['husband', 'children', 'children.toys', ''],
+                'House\\Item' => [ '' ]
             ],
             $command->getReversedPaths()
         );

--- a/tests/Iverberk/Larasearch/Commands/ReindexCommandTest.php
+++ b/tests/Iverberk/Larasearch/Commands/ReindexCommandTest.php
@@ -126,7 +126,7 @@ class ReindexCommandTest extends \PHPUnit_Framework_TestCase {
          */
         $model->shouldReceive('reindex')
             ->with(true, 750, null, \Mockery::type('closure'))
-            ->times(4)
+            ->times(5)
             ->andReturnUsing(function($relations, $batch, $mapping, $callback) {
                 $callback(1);
             });
@@ -143,22 +143,22 @@ class ReindexCommandTest extends \PHPUnit_Framework_TestCase {
 
         $command->shouldReceive('option')
             ->with('mapping')
-            ->times(4)
+            ->times(5)
             ->andReturn(false);
 
         $command->shouldReceive('option')
             ->with('relations')
-            ->times(4)
+            ->times(5)
             ->andReturn(true);
 
         $command->shouldReceive('option')
             ->with('batch')
-            ->times(4)
+            ->times(5)
             ->andReturn(750);
 
         $command->shouldReceive('info')->andReturn(true);
 
-        $command->shouldReceive('getModelInstance')->times(4)->andReturn($model);
+        $command->shouldReceive('getModelInstance')->times(5)->andReturn($model);
 
         /**
          *

--- a/tests/Iverberk/Larasearch/IndexTest.php
+++ b/tests/Iverberk/Larasearch/IndexTest.php
@@ -1291,6 +1291,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          *
          */
         $client->shouldReceive('indices->existsAlias')
+            ->twice()
             ->with(['name' => 'bar_Alias'])
             ->andReturn();
 
@@ -1300,6 +1301,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          *
          */
         $index->aliasExists('Alias');
+        $index->aliasExists('bar_Alias');
     }
 
     /**
@@ -1364,6 +1366,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          *
          */
         $client->shouldReceive('index')
+            ->twice()
             ->with([
                 'index' => 'bar_Husband',
                 'type' => 'Husband',
@@ -1371,12 +1374,17 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
                 'body' => 'data'
             ])
             ->andReturn();
-
         /**
          *
          * Assertion
          *
          */
+        $index->store([
+            'type' => 'Husband',
+            'id' => 1,
+            'data' => 'data'
+        ]);
+        $index->setName('bar_Husband');
         $index->store([
             'type' => 'Husband',
             'id' => 1,
@@ -1445,6 +1453,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          *
          */
         $client->shouldReceive('get')
+            ->twice()
             ->with([
                 'index' => 'bar_Husband',
                 'type' => 'Husband',
@@ -1457,6 +1466,12 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          * Assertion
          *
          */
+        $index->retrieve([
+            'type' => 'Husband',
+            'id' => 1,
+            'data' => 'data'
+        ]);
+        $index->setName('bar_Husband');
         $index->retrieve([
             'type' => 'Husband',
             'id' => 1,
@@ -1524,6 +1539,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          *
          */
         $client->shouldReceive('delete')
+            ->twice()
             ->with([
                 'index' => 'bar_Husband',
                 'type' => 'Husband',
@@ -1536,6 +1552,11 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          * Assertion
          *
          */
+        $index->remove([
+            'type' => 'Husband',
+            'id' => 1
+        ]);
+        $index->setName('bar_Husband');
         $index->remove([
             'type' => 'Husband',
             'id' => 1
@@ -1603,6 +1624,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          *
          */
         $client->shouldReceive('indices->analyze')
+            ->twice()
             ->with([
                 'index' => 'bar_Husband',
                 'text' => 'text',
@@ -1616,6 +1638,11 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          * Assertion
          *
          */
+        $index->tokens('text', [
+            'option1' => 1,
+            'option2' => 2
+        ]);
+        $index->setName('bar_Husband');
         $index->tokens('text', [
             'option1' => 1,
             'option2' => 2
@@ -1693,7 +1720,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
      * @test
      * @expectedException \Iverberk\Larasearch\Exceptions\ImportException
      */
-    public function it_should_store_a_records_having_prefix_in_bulk_with_errors()
+    public function it_should_store_records_having_prefix_in_bulk_with_errors()
     {
         /**
          *
@@ -1703,7 +1730,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          * @var \Mockery\Mock $proxy
          * @var \Mockery\Mock $client
          */
-        list($index, $proxy, $client) = $this->getMocks();
+        list($index, $proxy, $client) = $this->getMocks('bar_');
 
         /**
          *
@@ -1714,7 +1741,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
 
         $client->shouldReceive('bulk')
             ->with([
-                'index' => 'Husband',
+                'index' => 'bar_Husband',
                 'type' => 'Husband',
                 'body' => 'records'
             ])
@@ -1735,6 +1762,57 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          *
          */
         $index->bulk('records');
+        $index->setName('bar_Husband');
+        $index->bulk('records');;
+    }
+
+    /**
+     * @test
+     * @expectedException \Iverberk\Larasearch\Exceptions\ImportException
+     */
+    public function it_should_store_records_having_explicit_prefix_in_bulk_with_errors()
+    {
+        /**
+         *
+         * Set
+         *
+         * @var \Mockery\Mock $index
+         * @var \Mockery\Mock $proxy
+         * @var \Mockery\Mock $client
+         */
+        list($index, $proxy, $client) = $this->getMocks('bar_');
+
+        /**
+         *
+         * Expectation
+         *
+         */
+        $proxy->shouldReceive('getType')->andReturn('Husband');
+
+        $client->shouldReceive('bulk')
+            ->with([
+                'index' => 'bar_Husband',
+                'type' => 'Husband',
+                'body' => 'records'
+            ])
+            ->andReturn([
+                'errors' => true,
+                'items' => [
+                    [
+                        'index' => [
+                            'error' => true
+                        ]
+                    ]
+                ]
+            ]);
+
+        /**
+         *
+         * Assertion
+         *
+         */
+        $index->setName('bar_Husband');
+        $index->bulk('records');;
     }
 
     /**
@@ -1800,6 +1878,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
         $proxy->shouldReceive('getType')->andReturn('Husband');
 
         $client->shouldReceive('bulk')
+            ->twice()
             ->with([
                 'index' => 'bar_Husband',
                 'type' => 'Husband',
@@ -1814,6 +1893,8 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          * Assertion
          *
          */
+        $index->bulk('records');
+        $index->setName('bar_Husband');
         $index->bulk('records');
     }
 
@@ -1884,6 +1965,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          *
          */
         $client->shouldReceive('indices->getAliases')
+            ->twice()
             ->andReturn([
                 'bar_index_123456789101112' => [
                     'aliases' => []
@@ -1891,6 +1973,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
             ]);
 
         $client->shouldReceive('indices->delete')
+            ->twice()
             ->with([
                 'index' => 'bar_index_123456789101112'
             ]);
@@ -1901,6 +1984,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          *
          */
         Index::clean('index');
+        Index::clean('bar_index');
     }
 
     /**
@@ -1963,6 +2047,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          *
          */
         $client->shouldReceive('indices->updateAliases')
+            ->twice()
             ->with([
                 'body' => ['actions' => [ [ 'add' => ['index' => 'bar_Husband', 'alias' => 'bar_Father' ]]]]
             ]);
@@ -1972,6 +2057,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          * Assertion
          *
          */
+        Index::updateAliases(['actions' => [ [ 'add' => ['index' => 'Husband', 'alias' => 'Father' ]]]]);
         Index::updateAliases(['actions' => [ [ 'add' => ['index' => 'bar_Husband', 'alias' => 'bar_Father' ]]]]);
     }
 
@@ -2035,6 +2121,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          *
          */
         $client->shouldReceive('indices->getAlias')
+            ->twice()
             ->with([
                 'name' => 'bar_mock'
             ]);
@@ -2045,6 +2132,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          *
          */
         Index::getAlias('mock');
+        Index::getAlias('bar_mock');
     }
 
     /**
@@ -2107,6 +2195,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          *
          */
         $client->shouldReceive('indices->refresh')
+            ->twice()
             ->with([
                 'index' => 'bar_mock'
             ]);
@@ -2117,6 +2206,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          *
          */
         Index::refresh('mock');
+        Index::refresh('bar_mock');
     }
 
     /**

--- a/tests/Iverberk/Larasearch/IndexTest.php
+++ b/tests/Iverberk/Larasearch/IndexTest.php
@@ -81,7 +81,27 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          */
         $this->assertEquals($index, $index->setName('Mock'));
         $this->assertEquals('bar_Mock', $index->getName());
-    }
+	}
+
+    /**
+     * @test
+     */
+    public function it_should_only_prepend_prefix_once()
+	{
+        /**
+         *
+         * Set
+         *
+         * @var \Mockery\Mock $index
+         */
+        list($index) = $this->getMocks('baz_');
+
+		/**
+		 * Assertions
+		 */
+        $this->assertEquals($index, $index->setName('baz_MockMe'));
+		$this->assertEquals('baz_MockMe', $index->getName());
+	}
 
     /**
      * @test
@@ -600,6 +620,499 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
     /**
      * @test
      */
+    public function it_should_create_an_index_with_a_prefix()
+    {
+        /**
+         *
+         * Set
+         *
+         * @var \Mockery\Mock $index
+         * @var \Mockery\Mock $proxy
+         * @var \Mockery\Mock $client
+         */
+        list($index, $proxy, $client) = $this->getMocks('bar_');
+        $test = $this;
+
+        /**
+         *
+         * Expectation
+         *
+         */
+        Config::shouldReceive('get')
+            ->with('larasearch::elasticsearch.analyzers')
+            ->andReturn([
+                'autocomplete',
+                'suggest',
+                'text_start',
+                'text_middle',
+                'text_end',
+                'word_start',
+                'word_middle',
+                'word_end'
+            ]);
+
+        Config::shouldReceive('get')
+            ->with('larasearch::elasticsearch.defaults.index')
+            ->andReturn([
+                'settings' => [
+                    'number_of_shards' => 1,
+                    'number_of_replicas' => 0,
+                    'analysis' => [
+                        'analyzer' => [
+                            'larasearch_keyword' => [
+                                'type' => "custom",
+                                'tokenizer' => "keyword",
+                                'filter' => ["lowercase", "larasearch_stemmer"]
+                            ],
+                            'default_index' => [
+                                'type' => "custom",
+                                'tokenizer' => "standard",
+                                'filter' => ["standard", "lowercase", "asciifolding", "larasearch_index_shingle", "larasearch_stemmer"]
+                            ],
+                            'larasearch_search' => [
+                                'type' => "custom",
+                                'tokenizer' => "standard",
+                                'filter' => ["standard", "lowercase", "asciifolding", "larasearch_search_shingle", "larasearch_stemmer"]
+                            ],
+                            'larasearch_search2' => [
+                                'type' => "custom",
+                                'tokenizer' => "standard",
+                                'filter' => ["standard", "lowercase", "asciifolding", "larasearch_stemmer"]
+                            ],
+                            'larasearch_autocomplete_index' => [
+                                'type' => "custom",
+                                'tokenizer' => "larasearch_autocomplete_ngram",
+                                'filter' => ["lowercase", "asciifolding"]
+                            ],
+                            'larasearch_autocomplete_search' => [
+                                'type' => "custom",
+                                'tokenizer' => "keyword",
+                                'filter' => ["lowercase", "asciifolding"]
+                            ],
+                            'larasearch_word_search' => [
+                                'type' => "custom",
+                                'tokenizer' => "standard",
+                                'filter' => ["lowercase", "asciifolding"]
+                            ],
+                            'larasearch_suggest_index' => [
+                                'type' => "custom",
+                                'tokenizer' => "standard",
+                                'filter' => ["lowercase", "asciifolding", "larasearch_suggest_shingle"]
+                            ],
+                            'larasearch_text_start_index' => [
+                                'type' => "custom",
+                                'tokenizer' => "keyword",
+                                'filter' => ["lowercase", "asciifolding", "larasearch_edge_ngram"]
+                            ],
+                            'larasearch_text_middle_index' => [
+                                'type' => "custom",
+                                'tokenizer' => "keyword",
+                                'filter' => ["lowercase", "asciifolding", "larasearch_ngram"]
+                            ],
+                            'larasearch_text_end_index' => [
+                                'type' => "custom",
+                                'tokenizer' => "keyword",
+                                'filter' => ["lowercase", "asciifolding", "reverse", "larasearch_edge_ngram", "reverse"]
+                            ],
+                            'larasearch_word_start_index' => [
+                                'type' => "custom",
+                                'tokenizer' => "standard",
+                                'filter' => ["lowercase", "asciifolding", "larasearch_edge_ngram"]
+                            ],
+                            'larasearch_word_middle_index' => [
+                                'type' => "custom",
+                                'tokenizer' => "standard",
+                                'filter' => ["lowercase", "asciifolding", "larasearch_ngram"]
+                            ],
+                            'larasearch_word_end_index' => [
+                                'type' => "custom",
+                                'tokenizer' => "standard",
+                                'filter' => ["lowercase", "asciifolding", "reverse", "larasearch_edge_ngram", "reverse"]
+                            ]
+                        ],
+                        'filter' => [
+                            'larasearch_index_shingle' => [
+                                'type' => "shingle",
+                                'token_separator' => ""
+                            ],
+                            'larasearch_search_shingle' => [
+                                'type' => "shingle",
+                                'token_separator' => "",
+                                'output_unigrams' => false,
+                                'output_unigrams_if_no_shingles' => true
+                            ],
+                            'larasearch_suggest_shingle' => [
+                                'type' => "shingle",
+                                'max_shingle_size' => 5
+                            ],
+                            'larasearch_edge_ngram' => [
+                                'type' => "edgeNGram",
+                                'min_gram' => 1,
+                                'max_gram' => 50
+                            ],
+                            'larasearch_ngram' => [
+                                'type' => "nGram",
+                                'min_gram' => 1,
+                                'max_gram' => 50
+                            ],
+                            'larasearch_stemmer' => [
+                                'type' => "snowball",
+                                'language' => "English"
+                            ]
+                        ],
+                        'tokenizer' => [
+                            'larasearch_autocomplete_ngram' => [
+                                'type' => "edgeNGram",
+                                'min_gram' => 1,
+                                'max_gram' => 50
+                            ]
+                        ]
+                    ]
+                ]]);
+
+        $client->shouldReceive('indices->create')
+            ->andReturnUsing(function($params) use ($test) {
+                $test->assertEquals(json_decode(
+                        '{
+                          "index": "bar_Husband",
+                          "body": {
+                            "settings": {
+                              "number_of_shards": 1,
+                              "number_of_replicas": 0,
+                              "analysis": {
+                                "analyzer": {
+                                  "larasearch_keyword": {
+                                    "type": "custom",
+                                    "tokenizer": "keyword",
+                                    "filter": [
+                                      "lowercase",
+                                      "larasearch_stemmer"
+                                    ]
+                                  },
+                                  "default_index": {
+                                    "type": "custom",
+                                    "tokenizer": "standard",
+                                    "filter": [
+                                      "standard",
+                                      "lowercase",
+                                      "asciifolding",
+                                      "larasearch_index_shingle",
+                                      "larasearch_stemmer"
+                                    ]
+                                  },
+                                  "larasearch_search": {
+                                    "type": "custom",
+                                    "tokenizer": "standard",
+                                    "filter": [
+                                      "standard",
+                                      "lowercase",
+                                      "asciifolding",
+                                      "larasearch_search_shingle",
+                                      "larasearch_stemmer"
+                                    ]
+                                  },
+                                  "larasearch_search2": {
+                                    "type": "custom",
+                                    "tokenizer": "standard",
+                                    "filter": [
+                                      "standard",
+                                      "lowercase",
+                                      "asciifolding",
+                                      "larasearch_stemmer"
+                                    ]
+                                  },
+                                  "larasearch_autocomplete_index": {
+                                    "type": "custom",
+                                    "tokenizer": "larasearch_autocomplete_ngram",
+                                    "filter": [
+                                      "lowercase",
+                                      "asciifolding"
+                                    ]
+                                  },
+                                  "larasearch_autocomplete_search": {
+                                    "type": "custom",
+                                    "tokenizer": "keyword",
+                                    "filter": [
+                                      "lowercase",
+                                      "asciifolding"
+                                    ]
+                                  },
+                                  "larasearch_word_search": {
+                                    "type": "custom",
+                                    "tokenizer": "standard",
+                                    "filter": [
+                                      "lowercase",
+                                      "asciifolding"
+                                    ]
+                                  },
+                                  "larasearch_suggest_index": {
+                                    "type": "custom",
+                                    "tokenizer": "standard",
+                                    "filter": [
+                                      "lowercase",
+                                      "asciifolding",
+                                      "larasearch_suggest_shingle"
+                                    ]
+                                  },
+                                  "larasearch_text_start_index": {
+                                    "type": "custom",
+                                    "tokenizer": "keyword",
+                                    "filter": [
+                                      "lowercase",
+                                      "asciifolding",
+                                      "larasearch_edge_ngram"
+                                    ]
+                                  },
+                                  "larasearch_text_middle_index": {
+                                    "type": "custom",
+                                    "tokenizer": "keyword",
+                                    "filter": [
+                                      "lowercase",
+                                      "asciifolding",
+                                      "larasearch_ngram"
+                                    ]
+                                  },
+                                  "larasearch_text_end_index": {
+                                    "type": "custom",
+                                    "tokenizer": "keyword",
+                                    "filter": [
+                                      "lowercase",
+                                      "asciifolding",
+                                      "reverse",
+                                      "larasearch_edge_ngram",
+                                      "reverse"
+                                    ]
+                                  },
+                                  "larasearch_word_start_index": {
+                                    "type": "custom",
+                                    "tokenizer": "standard",
+                                    "filter": [
+                                      "lowercase",
+                                      "asciifolding",
+                                      "larasearch_edge_ngram"
+                                    ]
+                                  },
+                                  "larasearch_word_middle_index": {
+                                    "type": "custom",
+                                    "tokenizer": "standard",
+                                    "filter": [
+                                      "lowercase",
+                                      "asciifolding",
+                                      "larasearch_ngram"
+                                    ]
+                                  },
+                                  "larasearch_word_end_index": {
+                                    "type": "custom",
+                                    "tokenizer": "standard",
+                                    "filter": [
+                                      "lowercase",
+                                      "asciifolding",
+                                      "reverse",
+                                      "larasearch_edge_ngram",
+                                      "reverse"
+                                    ]
+                                  }
+                                },
+                                "filter": {
+                                  "larasearch_index_shingle": {
+                                    "type": "shingle",
+                                    "token_separator": ""
+                                  },
+                                  "larasearch_search_shingle": {
+                                    "type": "shingle",
+                                    "token_separator": "",
+                                    "output_unigrams": false,
+                                    "output_unigrams_if_no_shingles": true
+                                  },
+                                  "larasearch_suggest_shingle": {
+                                    "type": "shingle",
+                                    "max_shingle_size": 5
+                                  },
+                                  "larasearch_edge_ngram": {
+                                    "type": "edgeNGram",
+                                    "min_gram": 1,
+                                    "max_gram": 50
+                                  },
+                                  "larasearch_ngram": {
+                                    "type": "nGram",
+                                    "min_gram": 1,
+                                    "max_gram": 50
+                                  },
+                                  "larasearch_stemmer": {
+                                    "type": "snowball",
+                                    "language": "English"
+                                  }
+                                },
+                                "tokenizer": {
+                                  "larasearch_autocomplete_ngram": {
+                                    "type": "edgeNGram",
+                                    "min_gram": 1,
+                                    "max_gram": 50
+                                  }
+                                }
+                              }
+                            },
+                            "mappings": {
+                              "_default_": {
+                                "properties": {
+                                  "name": {
+                                    "type": "multi_field",
+                                    "fields": {
+                                      "name": {
+                                        "type": "string",
+                                        "index": "not_analyzed"
+                                      },
+                                      "analyzed": {
+                                        "type": "string",
+                                        "index": "analyzed"
+                                      },
+                                      "autocomplete": {
+                                        "type": "string",
+                                        "index": "analyzed",
+                                        "analyzer": "larasearch_autocomplete_index"
+                                      },
+                                      "suggest": {
+                                        "type": "string",
+                                        "index": "analyzed",
+                                        "analyzer": "larasearch_suggest_index"
+                                      },
+                                      "text_start": {
+                                        "type": "string",
+                                        "index": "analyzed",
+                                        "analyzer": "larasearch_text_start_index"
+                                      },
+                                      "text_middle": {
+                                        "type": "string",
+                                        "index": "analyzed",
+                                        "analyzer": "larasearch_text_middle_index"
+                                      },
+                                      "text_end": {
+                                        "type": "string",
+                                        "index": "analyzed",
+                                        "analyzer": "larasearch_text_end_index"
+                                      },
+                                      "word_start": {
+                                        "type": "string",
+                                        "index": "analyzed",
+                                        "analyzer": "larasearch_word_start_index"
+                                      },
+                                      "word_middle": {
+                                        "type": "string",
+                                        "index": "analyzed",
+                                        "analyzer": "larasearch_word_middle_index"
+                                      },
+                                      "word_end": {
+                                        "type": "string",
+                                        "index": "analyzed",
+                                        "analyzer": "larasearch_word_end_index"
+                                      }
+                                    }
+                                  },
+                                  "wife": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "multi_field",
+                                        "fields": {
+                                          "name": {
+                                            "type": "string",
+                                            "index": "not_analyzed"
+                                          },
+                                          "analyzed": {
+                                            "type": "string",
+                                            "index": "analyzed"
+                                          },
+                                          "autocomplete": {
+                                            "type": "string",
+                                            "index": "analyzed",
+                                            "analyzer": "larasearch_autocomplete_index"
+                                          }
+                                        }
+                                      },
+                                      "children": {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "multi_field",
+                                            "fields": {
+                                              "name": {
+                                                "type": "string",
+                                                "index": "not_analyzed"
+                                              },
+                                              "analyzed": {
+                                                "type": "string",
+                                                "index": "analyzed"
+                                              },
+                                              "text_start": {
+                                                "type": "string",
+                                                "index": "analyzed",
+                                                "analyzer": "larasearch_text_start_index"
+                                              },
+                                              "text_middle": {
+                                                "type": "string",
+                                                "index": "analyzed",
+                                                "analyzer": "larasearch_text_middle_index"
+                                              },
+                                              "text_end": {
+                                                "type": "string",
+                                                "index": "analyzed",
+                                                "analyzer": "larasearch_text_end_index"
+                                              },
+                                              "word_start": {
+                                                "type": "string",
+                                                "index": "analyzed",
+                                                "analyzer": "larasearch_word_start_index"
+                                              },
+                                              "word_middle": {
+                                                "type": "string",
+                                                "index": "analyzed",
+                                                "analyzer": "larasearch_word_middle_index"
+                                              },
+                                              "word_end": {
+                                                "type": "string",
+                                                "index": "analyzed",
+                                                "analyzer": "larasearch_word_end_index"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "index": "bar_Husband",
+                            "type": "Husband"
+                          }
+                        }', true)
+                    ,
+                    $params);
+            });
+
+        $proxy->shouldReceive('getType')->andReturn('Husband');
+        $proxy->shouldReceive('getConfig')->andReturn([
+                'autocomplete' => ['name', 'wife.name'],
+                'suggest' => ['name'],
+                'text_start' => ['name', 'wife.children.name'],
+                'text_middle' => ['name', 'wife.children.name'],
+                'text_end' => ['name', 'wife.children.name'],
+                'word_start' => ['name', 'wife.children.name'],
+                'word_middle' => ['name', 'wife.children.name'],
+                'word_end' => ['name', 'wife.children.name']
+        ]);
+
+        /**
+         *
+         * Assertion
+         *
+         */
+        $index->create();
+    }
+
+    /**
+     * @test
+     */
     public function it_should_delete_an_index()
     {
         /**
@@ -619,6 +1132,38 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          */
         $client->shouldReceive('indices->delete')
             ->with(['index' => 'Husband'])
+            ->andReturn();
+
+        /**
+         *
+         * Assertion
+         *
+         */
+        $index->delete();
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_delete_an_index_with_a_prefix()
+    {
+        /**
+         *
+         * Set
+         *
+         * @var \Mockery\Mock $index
+         * @var \Mockery\Mock $proxy
+         * @var \Mockery\Mock $client
+         */
+        list($index, $proxy, $client) = $this->getMocks('bar_');
+
+        /**
+         *
+         * Expectation
+         *
+         */
+        $client->shouldReceive('indices->delete')
+            ->with(['index' => 'bar_Husband'])
             ->andReturn();
 
         /**
@@ -664,6 +1209,38 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
     /**
      * @test
      */
+    public function it_should_check_that_an_index_exists_with_a_prefix()
+    {
+        /**
+         *
+         * Set
+         *
+         * @var \Mockery\Mock $index
+         * @var \Mockery\Mock $proxy
+         * @var \Mockery\Mock $client
+         */
+        list($index, $proxy, $client) = $this->getMocks('bar_');
+
+        /**
+         *
+         * Expectation
+         *
+         */
+        $client->shouldReceive('indices->exists')
+            ->with(['index' => 'bar_Husband'])
+            ->andReturn();
+
+        /**
+         *
+         * Assertion
+         *
+         */
+        $index->exists();
+    }
+
+    /**
+     * @test
+     */
     public function it_should_check_that_an_alias_exists()
     {
         /**
@@ -683,6 +1260,38 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
          */
         $client->shouldReceive('indices->existsAlias')
             ->with(['name' => 'Alias'])
+            ->andReturn();
+
+        /**
+         *
+         * Assertion
+         *
+         */
+        $index->aliasExists('Alias');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_check_that_an_alias_exists_with_a_prefix()
+    {
+        /**
+         *
+         * Set
+         *
+         * @var \Mockery\Mock $index
+         * @var \Mockery\Mock $proxy
+         * @var \Mockery\Mock $client
+         */
+        list($index, $proxy, $client) = $this->getMocks('bar_');
+
+        /**
+         *
+         * Expectation
+         *
+         */
+        $client->shouldReceive('indices->existsAlias')
+            ->with(['name' => 'bar_Alias'])
             ->andReturn();
 
         /**
@@ -716,6 +1325,47 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
         $client->shouldReceive('index')
             ->with([
                 'index' => 'Husband',
+                'type' => 'Husband',
+                'id' => 1,
+                'body' => 'data'
+            ])
+            ->andReturn();
+
+        /**
+         *
+         * Assertion
+         *
+         */
+        $index->store([
+            'type' => 'Husband',
+            'id' => 1,
+            'data' => 'data'
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_store_a_record_with_an_index_prefix()
+    {
+        /**
+         *
+         * Set
+         *
+         * @var \Mockery\Mock $index
+         * @var \Mockery\Mock $proxy
+         * @var \Mockery\Mock $client
+         */
+        list($index, $proxy, $client) = $this->getMocks('bar_');
+
+        /**
+         *
+         * Expectation
+         *
+         */
+        $client->shouldReceive('index')
+            ->with([
+                'index' => 'bar_Husband',
                 'type' => 'Husband',
                 'id' => 1,
                 'body' => 'data'
@@ -777,6 +1427,46 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
     /**
      * @test
      */
+    public function it_should_retrieve_a_record_iwth_an_index_prefix()
+    {
+        /**
+         *
+         * Set
+         *
+         * @var \Mockery\Mock $index
+         * @var \Mockery\Mock $proxy
+         * @var \Mockery\Mock $client
+         */
+        list($index, $proxy, $client) = $this->getMocks('bar_');
+
+        /**
+         *
+         * Expectation
+         *
+         */
+        $client->shouldReceive('get')
+            ->with([
+                'index' => 'bar_Husband',
+                'type' => 'Husband',
+                'id' => 1,
+            ])
+            ->andReturn();
+
+        /**
+         *
+         * Assertion
+         *
+         */
+        $index->retrieve([
+            'type' => 'Husband',
+            'id' => 1,
+            'data' => 'data'
+        ]);
+    }
+
+    /**
+     * @test
+     */
     public function it_should_remove_a_record()
     {
         /**
@@ -797,6 +1487,45 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
         $client->shouldReceive('delete')
             ->with([
                 'index' => 'Husband',
+                'type' => 'Husband',
+                'id' => 1
+            ])
+            ->andReturn();
+
+        /**
+         *
+         * Assertion
+         *
+         */
+        $index->remove([
+            'type' => 'Husband',
+            'id' => 1
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_remove_a_record_with_an_index_prefix()
+    {
+        /**
+         *
+         * Set
+         *
+         * @var \Mockery\Mock $index
+         * @var \Mockery\Mock $proxy
+         * @var \Mockery\Mock $client
+         */
+        list($index, $proxy, $client) = $this->getMocks('bar_');
+
+        /**
+         *
+         * Expectation
+         *
+         */
+        $client->shouldReceive('delete')
+            ->with([
+                'index' => 'bar_Husband',
                 'type' => 'Husband',
                 'id' => 1
             ])
@@ -856,6 +1585,46 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
     /**
      * @test
      */
+    public function it_should_inspect_tokens_with_an_index_prefix()
+    {
+        /**
+         *
+         * Set
+         *
+         * @var \Mockery\Mock $index
+         * @var \Mockery\Mock $proxy
+         * @var \Mockery\Mock $client
+         */
+        list($index, $proxy, $client) = $this->getMocks('bar_');
+
+        /**
+         *
+         * Expectation
+         *
+         */
+        $client->shouldReceive('indices->analyze')
+            ->with([
+                'index' => 'bar_Husband',
+                'text' => 'text',
+                'option1' => 1,
+                'option2' => 2
+            ])
+            ->andReturn();
+
+        /**
+         *
+         * Assertion
+         *
+         */
+        $index->tokens('text', [
+            'option1' => 1,
+            'option2' => 2
+        ]);
+    }
+
+    /**
+     * @test
+     */
     public function it_should_get_and_set_params()
     {
         /**
@@ -877,6 +1646,54 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
      * @expectedException \Iverberk\Larasearch\Exceptions\ImportException
      */
     public function it_should_store_a_records_in_bulk_with_errors()
+    {
+        /**
+         *
+         * Set
+         *
+         * @var \Mockery\Mock $index
+         * @var \Mockery\Mock $proxy
+         * @var \Mockery\Mock $client
+         */
+        list($index, $proxy, $client) = $this->getMocks('bar_');
+
+        /**
+         *
+         * Expectation
+         *
+         */
+        $proxy->shouldReceive('getType')->andReturn('Husband');
+
+        $client->shouldReceive('bulk')
+            ->with([
+                'index' => 'bar_Husband',
+                'type' => 'Husband',
+                'body' => 'records'
+            ])
+            ->andReturn([
+                'errors' => true,
+                'items' => [
+                    [
+                        'index' => [
+                            'error' => true
+                        ]
+                    ]
+                ]
+            ]);
+
+        /**
+         *
+         * Assertion
+         *
+         */
+        $index->bulk('records');
+    }
+
+    /**
+     * @test
+     * @expectedException \Iverberk\Larasearch\Exceptions\ImportException
+     */
+    public function it_should_store_a_records_having_prefix_in_bulk_with_errors()
     {
         /**
          *
@@ -963,6 +1780,46 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
     /**
      * @test
      */
+    public function it_should_store_a_records_having_index_prefix_in_bulk_without_errors()
+    {
+        /**
+         *
+         * Set
+         *
+         * @var \Mockery\Mock $index
+         * @var \Mockery\Mock $proxy
+         * @var \Mockery\Mock $client
+         */
+        list($index, $proxy, $client) = $this->getMocks('bar_');
+
+        /**
+         *
+         * Expectation
+         *
+         */
+        $proxy->shouldReceive('getType')->andReturn('Husband');
+
+        $client->shouldReceive('bulk')
+            ->with([
+                'index' => 'bar_Husband',
+                'type' => 'Husband',
+                'body' => 'records'
+            ])
+            ->andReturn([
+                'errors' => false
+            ]);
+
+        /**
+         *
+         * Assertion
+         *
+         */
+        $index->bulk('records');
+    }
+
+    /**
+     * @test
+     */
     public function it_should_clean_old_indices()
     {
         /**
@@ -993,6 +1850,49 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
         $client->shouldReceive('indices->delete')
             ->with([
                 'index' => 'index_123456789101112'
+            ]);
+
+        /**
+         *
+         * Assertion
+         *
+         */
+        Index::clean('index');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_clean_old_indices_with_index_prefix()
+    {
+        /**
+         *
+         * Set
+         *
+         * @var \Mockery\Mock $index
+         * @var \Mockery\Mock $proxy
+         * @var \Mockery\Mock $client
+         */
+        list($index, $proxy, $client) = $this->getMocks('bar_');
+
+        // Mock the self::$client variable
+        am::double('Iverberk\Larasearch\Index', ['self::$client' => $client]);
+
+        /**
+         *
+         * Expectation
+         *
+         */
+        $client->shouldReceive('indices->getAliases')
+            ->andReturn([
+                'bar_index_123456789101112' => [
+                    'aliases' => []
+                ]
+            ]);
+
+        $client->shouldReceive('indices->delete')
+            ->with([
+                'index' => 'bar_index_123456789101112'
             ]);
 
         /**
@@ -1042,6 +1942,42 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
     /**
      * @test
      */
+    public function it_should_update_aliases_with_index_prefix()
+    {
+        /**
+         *
+         * Set
+         *
+         * @var \Mockery\Mock $index
+         * @var \Mockery\Mock $proxy
+         * @var \Mockery\Mock $client
+         */
+        list($index, $proxy, $client) = $this->getMocks('bar_');
+
+        // Mock the self::$client variable
+        am::double('Iverberk\Larasearch\Index', ['self::$client' => $client]);
+
+        /**
+         *
+         * Expectation
+         *
+         */
+        $client->shouldReceive('indices->updateAliases')
+            ->with([
+                'body' => ['actions' => [ [ 'add' => ['index' => 'bar_Husband', 'alias' => 'bar_Father' ]]]]
+            ]);
+
+        /**
+         *
+         * Assertion
+         *
+         */
+        Index::updateAliases(['actions' => [ [ 'add' => ['index' => 'bar_Husband', 'alias' => 'bar_Father' ]]]]);
+    }
+
+    /**
+     * @test
+     */
     public function it_should_get_aliases()
     {
         /**
@@ -1065,6 +2001,42 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
         $client->shouldReceive('indices->getAlias')
             ->with([
                 'name' => 'mock'
+            ]);
+
+        /**
+         *
+         * Assertion
+         *
+         */
+        Index::getAlias('mock');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_get_aliases_with_an_index_prefix()
+    {
+        /**
+         *
+         * Set
+         *
+         * @var \Mockery\Mock $index
+         * @var \Mockery\Mock $proxy
+         * @var \Mockery\Mock $client
+         */
+        list($index, $proxy, $client) = $this->getMocks('bar_');
+
+        // Mock the self::$client variable
+        am::double('Iverberk\Larasearch\Index', ['self::$client' => $client]);
+
+        /**
+         *
+         * Expectation
+         *
+         */
+        $client->shouldReceive('indices->getAlias')
+            ->with([
+                'name' => 'bar_mock'
             ]);
 
         /**
@@ -1112,6 +2084,42 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
+     * @test
+     */
+    public function it_should_refresh_with_an_index_prefix()
+    {
+        /**
+         *
+         * Set
+         *
+         * @var \Mockery\Mock $index
+         * @var \Mockery\Mock $proxy
+         * @var \Mockery\Mock $client
+         */
+        list($index, $proxy, $client) = $this->getMocks('bar_');
+
+        // Mock the self::$client variable
+        am::double('Iverberk\Larasearch\Index', ['self::$client' => $client]);
+
+        /**
+         *
+         * Expectation
+         *
+         */
+        $client->shouldReceive('indices->refresh')
+            ->with([
+                'index' => 'bar_mock'
+            ]);
+
+        /**
+         *
+         * Assertion
+         *
+         */
+        Index::refresh('mock');
+    }
+
+    /**
      * Construct an Index mock
      *
      * @return array
@@ -1138,7 +2146,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase {
         $proxy->shouldReceive('getModel->getTable')
             ->andReturn('Husband');
 
-        $index = m::mock('Iverberk\Larasearch\Index', [$proxy])->makePartial();
+        $index = m::mock('Iverberk\Larasearch\Index', [$proxy], [ m::BLOCKS => ['setName', 'setProxy']])->makePartial();
 
         return [$index, $proxy, $client];
     }

--- a/tests/Iverberk/Larasearch/UtilsTest.php
+++ b/tests/Iverberk/Larasearch/UtilsTest.php
@@ -63,6 +63,7 @@ class UtilsTest extends \PHPUnit_Framework_TestCase {
         $this->assertContains('Wife', $models);
         $this->assertContains('Toy', $models);
         $this->assertContains('Child', $models);
+        $this->assertContains('House\\Item', $models);
     }
 
 }

--- a/tests/Support/Stubs/Foo/Bar.php
+++ b/tests/Support/Stubs/Foo/Bar.php
@@ -1,0 +1,9 @@
+<?php namespace House;
+
+use Iverberk\Larasearch\Traits\SearchableTrait;
+
+class Item extends \Illuminate\Database\Eloquent\Model {
+
+    use SearchableTrait;
+
+}


### PR DESCRIPTION
# The larasearch:paths command could not handle directories with directories inside of it.  This fixes that.
# The larasearch:paths command would get tripped up when the world 'class' appeared at the end of a comment.
# Added extensive testing for index_prefix to ensure the prefix would not be applied twice.  I initially thought it would be better to mock out responses from accessors but found a better way to test in the end though left the getters and setters in place.
# phpunit/phpunit 4.5._@dev does not point to dev-master anymore so had to update to 4.6._@dev.
