### PR TITLE
Change property visibility in SearchableTrait

### DIFF
--- a/src/Iverberk/Larasearch/Traits/SearchableTrait.php
+++ b/src/Iverberk/Larasearch/Traits/SearchableTrait.php
@@ -13,7 +13,7 @@ trait SearchableTrait {
 	 *
 	 * @var \Iverberk\Larasearch\Proxy
 	 */
-	private static $__es_proxy = null;
+	protected static $__es_proxy = null;
 
 	/**
 	 * Related Eloquent models as dot seperated paths


### PR DESCRIPTION
Allows you to use trait in different models sharing one base class (in multi-table inheritance in our case).