### PR TITLE
Skip sub directories in findSearchableModels()

### DIFF
--- a/src/Iverberk/Larasearch/Utils.php
+++ b/src/Iverberk/Larasearch/Utils.php
@@ -72,7 +72,7 @@ class Utils {
 			{
 				$namespace = '';
 
-				if (!$fileinfo->isDot() && $fileinfo->isReadable())
+				if (!$fileinfo->isDot() && !$fileinfo->isDir() && $fileinfo->isReadable())
 				{
 					$fileObj = $fileinfo->openFile('r');
 


### PR DESCRIPTION
Skip sub directories inside your model dir instead of trying to read them.