### PR TITLE
Add a --depth option to PathsCommand

### DIFF
--- a/tests/Iverberk/Larasearch/Commands/PathsCommandTest.php
+++ b/tests/Iverberk/Larasearch/Commands/PathsCommandTest.php
@@ -162,10 +162,10 @@ class PathsCommandTest extends \PHPUnit_Framework_TestCase {
 
         assertEquals(
             [
-                'Husband' => ['', 'children', 'children.toys', 'wife'],
-                'Child' => ['mother.husband', '', 'toys', 'mother'],
-                'Toy' => ['children.mother.husband', 'children', '', 'children.mother'],
-                'Wife' => ['husband', 'children', 'children.toys', ''],
+                'Husband' => ['', 'wife', 'children.toys', 'children'],
+                'Child' => ['mother.husband', 'mother', 'toys', ''],
+                'Toy' => ['children.mother.husband', 'children.mother', '', 'children'],
+                'Wife' => ['husband', '', 'children.toys', 'children'],
                 'House\\Item' => [ '' ]
             ],
             $command->getReversedPaths()


### PR DESCRIPTION
We have quite a large amount of models that all inter-relate, making the paths very long and the data returned from Elasticsearch too large. The current implementation requires adding @follow annotations to all models which would take a long time and create difficulty in maintaining the codebase.

I have added a --depth option to larasearch:path which limits the number of steps in a path, avoiding the need to annotate every relationship.
