### PR TITLE
Fix

### DIFF
--- a/src/Iverberk/Larasearch/Index.php
+++ b/src/Iverberk/Larasearch/Index.php
@@ -288,7 +288,7 @@ class Index {
 
         $results = self::getClient()->bulk($params);
 
-        if ($results['errors'])
+        if (array_key_exists('errors', $results))
         {
             $errorItems = [];
 


### PR DESCRIPTION
Fix for checking if ['errors'] index exists. This to fix `php artisan larasearch:reindex` command exception.

``` ssh
[ErrorException]
  Undefined index: errors
```
