### PR TITLE
fix error when executing larasearch:reindex

### DIFF
--- a/src/Iverberk/Larasearch/Traits/SearchableTrait.php
+++ b/src/Iverberk/Larasearch/Traits/SearchableTrait.php
@@ -43,7 +43,7 @@ trait SearchableTrait {
 
             if ($instance instanceof Model)
             {
-                static::$__es_proxy = App::make('iverberk.larasearch.proxy', $instance);
+                static::$__es_proxy = new \Iverberk\Larasearch\Proxy($instance);
 
                 return static::$__es_proxy;
             } else


### PR DESCRIPTION
Hi and thanks a lot for your amazing work on this package !

I get an error when executing laraseach:reindex --relations with laravel 5.1 :+1: 

[ErrorException]
Argument 2 passed to Illuminate\Foundation\Application::make() must be of the type array, object given, called in /var/www/matcher/vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php on line 213 and defined

This commit solved it for me, hope it may help.

Thanks again for sharing your work !

Gael
