### PR TITLE
Fixed incorrect config import/dependancy on DeleteJob

### DIFF
--- a/src/Iverberk/Larasearch/Jobs/DeleteJob.php
+++ b/src/Iverberk/Larasearch/Jobs/DeleteJob.php
@@ -1,6 +1,6 @@
 <?php namespace Iverberk\Larasearch\Jobs;
 
-use Iverberk\Larasearch\Config;
+use Illuminate\Config\Repository;
 use Illuminate\Foundation\Application;
 use Illuminate\Queue\Jobs\Job;
 
@@ -25,7 +25,7 @@ class DeleteJob {
      * @param Application $app
      * @param Config
      */
-    public function __construct(Application $app, Config $config)
+    public function __construct(Application $app, Repository $config)
     {
         $this->app = $app;
         $this->config = $config;


### PR DESCRIPTION
Issue when ->delete()ing on models.

A quick side note, it might be nicer to use

``` php
$this->app = $app;
$this->config = $app->config;
```

for dependancy injection. If you agree, I can add this to the PR.
