### PR TITLE
Use array for $params in App::make()

### DIFF
--- a/src/Iverberk/Larasearch/LarasearchServiceProvider.php
+++ b/src/Iverberk/Larasearch/LarasearchServiceProvider.php
@@ -112,9 +112,9 @@ class LarasearchServiceProvider extends ServiceProvider
      */
     protected function bindProxy()
     {
-        $this->app->bind('iverberk.larasearch.proxy', function ($app, $model)
+        $this->app->bind('iverberk.larasearch.proxy', function ($app, $params)
         {
-            return new Proxy($model);
+            return new Proxy($params['model']);
         });
     }
 

--- a/src/Iverberk/Larasearch/Traits/SearchableTrait.php
+++ b/src/Iverberk/Larasearch/Traits/SearchableTrait.php
@@ -43,7 +43,7 @@ trait SearchableTrait {
 
             if ($instance instanceof Model)
             {
-                static::$__es_proxy = App::make('iverberk.larasearch.proxy', $instance);
+                static::$__es_proxy = App::make('iverberk.larasearch.proxy', ['model' => $instance]);
 
                 return static::$__es_proxy;
             } else


### PR DESCRIPTION
Updated Proxy binding to match syntax of other bindings. Using `['model' => $instance]` as `App::make()` requires 2nd argument to be an array and an object is given. This PR keeps original bindings within `LarasearchServiceProvider.php` and doesn't change anything else.
